### PR TITLE
fix: only remove the 'v' prefix from the git tag name (#45132)

### DIFF
--- a/script/get-git-version.py
+++ b/script/get-git-version.py
@@ -2,6 +2,7 @@
 
 import subprocess
 import os
+import re
 
 # Find the nearest tag to the current HEAD.
 # This is equivalent to our old logic of "use a value in package.json" for the
@@ -24,7 +25,8 @@ try:
       cwd=os.path.abspath(os.path.join(os.path.dirname(__file__), '..')),
       stderr=subprocess.PIPE,
       universal_newlines=True)
-  version = output.strip().replace('v', '')
+  # only remove the 'v' prefix from the tag name.
+  version = re.sub('^v', '', output.strip())
   print(version)
 except Exception:
   # When there is error we print a null version string instead of throwing an


### PR DESCRIPTION
In the old version of get-version.js, it replaces the leading 'v', i.e. |output.stdout.toString().trim().replace(/^v/g, '')|. However, in the new version of get-git-version.py, it directly replaces all 'v'. Obviously, it does not conform to the original semantics. Although it will not affect the existing electron version calculation, it may affect other developers' customized git-tag-version, such as v0.0.0-dev.xxx, which will lose the 'v' of dev.

#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant documentation, tutorials, templates and examples are changed or added
- [ ] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->
